### PR TITLE
Change to the new artifactory domain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,13 +52,13 @@
     <repository>
       <id>camunda-nexus</id>
       <name>camunda bpm community extensions</name>
-      <url>https://app.camunda.com/nexus/content/repositories/camunda-bpm-community-extensions</url>
+      <url>https://artifacts.camunda.com/artifactory/camunda-bpm-community-extensions/</url>
     </repository>
     <snapshotRepository>
       <id>camunda-nexus</id>
       <name>camunda bpm community extensions snapshots</name>
       <url>
-        https://app.camunda.com/nexus/content/repositories/camunda-bpm-community-extensions-snapshots
+        https://artifacts.camunda.com/artifactory/camunda-bpm-community-extensions-snapshots/
       </url>
       <!-- for maven 2 compatibility -->
       <uniqueVersion>true</uniqueVersion>


### PR DESCRIPTION
As announced in #engineering slack channel, we created a new Artifactory domain since the nexus one used now is a proxy URL and will be removed in the future.

Related to INFRA-3114